### PR TITLE
feat(azure-storage): service principal credentials

### DIFF
--- a/azure_storage/config.yaml
+++ b/azure_storage/config.yaml
@@ -19,9 +19,41 @@ options:
       Possible values: "wasb", "wasbs" for Azure Blob Storage and 
       "abfs", "abfss" for Azure Data Lake Storage v2.
     default: 'abfss'
+  resource-group:
+    type: string
+    description: |
+      The name of the Azure resource group where the storage account is located. 
+      This is optional and can be used to specify a different resource group.
+    default: ''
+  endpoint:
+    type: string
+    description: |
+      The endpoint URL for the Azure Storage account. This is optional and can be 
+      used to override the default endpoint URL.
+    default: ''
+  client-id:
+    type: string
+    description: |
+      The client ID of the service principal used to authenticate with Azure Storage. 
+      This is optional and can be used if using a service principal for authentication.
+    default: ''
+  tenant-id:
+    type: string
+    description: |
+      The tenant ID of the service principal used to authenticate with Azure Storage. 
+      This is optional and can be used if using a service principal for authentication.
+    default: ''
+  subscription-id:
+    type: string
+    description: |
+      The subscription ID of the service principal used to authenticate with Azure Storage. 
+      This is optional and can be used if using a service principal for authentication.
+    default: ''
   credentials:
     type: secret
     description: |
       The credentials to connect to Azure Storage account. This needs to be a Juju 
-      Secret URI pointing to a secret that contains the following keys:
-      1. secret-key: The secret key corresponding to the Azure Storage account.
+      Secret URI pointing to a secret that contains either the storage account key or client secret for a service principal.
+      - secret-key: The secret key corresponding to the Azure Storage account.
+      - client-id: The client ID of the service principal.
+      Note: Only one of these options should be provided.

--- a/azure_storage/src/constants.py
+++ b/azure_storage/src/constants.py
@@ -10,4 +10,8 @@ AZURE_RELATION_NAME = "azure-storage-credentials"
 
 AZURE_MANDATORY_OPTIONS = ["container", "storage-account", "credentials", "connection-protocol"]
 
-KEYS_LIST = ["secret-key"]
+AZURE_SERVICE_PRINCIPAL_OPTIONS = [
+    "client-id",
+    "tenant-id",
+    "subscription-id",
+]

--- a/azure_storage/src/core/context.py
+++ b/azure_storage/src/core/context.py
@@ -12,7 +12,7 @@ from ops import ConfigData, Model
 from constants import AZURE_MANDATORY_OPTIONS
 from core.domain import AzureConnectionInfo
 from utils.logging import WithLogging
-from utils.secrets import decode_secret_key
+from utils.secrets import decode_secret
 
 
 class Context(WithLogging):
@@ -29,17 +29,30 @@ class Context(WithLogging):
             if self.charm_config.get(opt) is None:
                 return None
 
-        credentials = self.charm_config.get("credentials")
+        storage_account_secret = None
+        service_principal_secret = None
         try:
-            secret_key = decode_secret_key(self.model, credentials)
+            secret = decode_secret(self.model, self.charm_config.get("credentials"))
+            storage_account_secret = secret.get("secret-key")
+            service_principal_secret = secret.get("client-secret")
         except Exception as e:
             self.logger.warning(str(e))
-            secret_key = ""
+
+        secret_key = ""
+        if bool(storage_account_secret) != bool(service_principal_secret):
+            secret_key = storage_account_secret or service_principal_secret
 
         return AzureConnectionInfo(
             connection_protocol=self.charm_config.get("connection-protocol"),
             container=self.charm_config.get("container"),
             storage_account=self.charm_config.get("storage-account"),
-            secret_key=secret_key,
+            endpoint=self.charm_config.get("endpoint"),
+            resource_group=self.charm_config.get("resource-group"),
             path=self.charm_config.get("path"),
+            secret_key=secret_key,
+            tenant_id=self.charm_config.get("tenant-id") if service_principal_secret else None,
+            client_id=self.charm_config.get("client-id") if service_principal_secret else None,
+            subscription_id=self.charm_config.get("subscription-id")
+            if service_principal_secret
+            else None,
         )

--- a/azure_storage/src/core/domain.py
+++ b/azure_storage/src/core/domain.py
@@ -16,11 +16,18 @@ class AzureConnectionInfo:
     container: str
     storage_account: str
     secret_key: str
+    client_id: str = None
+    tenant_id: str = None
+    subscription_id: str = None
+    endpoint: str = None
+    resource_group: str = None
     path: str = None
 
     @property
-    def endpoint(self):
+    def derived_endpoint(self):
         """The endpoint constructed from the other parameters."""
+        if self.endpoint:
+            return self.endpoint
         if self.connection_protocol.lower() in ("wasb", "wasbs"):
             return f"{self.connection_protocol}://{self.container}@{self.storage_account}.blob.core.windows.net/"
         elif self.connection_protocol.lower() in ("abfs", "abfss"):
@@ -34,8 +41,14 @@ class AzureConnectionInfo:
             "container": self.container,
             "storage-account": self.storage_account,
             "secret-key": self.secret_key,
-            "endpoint": self.endpoint,
+            "endpoint": self.derived_endpoint,
         }
         if self.path:
             data["path"] = self.path
+        if self.resource_group:
+            data["resource-group"] = self.resource_group
+        if self.client_id and self.tenant_id and self.subscription_id:
+            data["client-id"] = self.client_id
+            data["tenant-id"] = self.tenant_id
+            data["subscription-id"] = self.subscription_id
         return data

--- a/azure_storage/src/utils/secrets.py
+++ b/azure_storage/src/utils/secrets.py
@@ -4,7 +4,6 @@
 """Utility functions related to secrets."""
 
 import logging
-from typing import Optional
 
 import ops
 import ops.charm
@@ -16,8 +15,8 @@ import ops.model
 logger = logging.getLogger(__name__)
 
 
-def decode_secret_key(model: ops.Model, secret_id: str) -> Optional[str]:
-    """Decode the secret with given secret_id and return the secret-key in plaintext value.
+def decode_secret(model: ops.Model, secret_id: str) -> dict:
+    """Decode the secret with given secret_id and return the content as dictionary.
 
     Args:
         model: juju model
@@ -30,14 +29,10 @@ def decode_secret_key(model: ops.Model, secret_id: str) -> Optional[str]:
             yet.
 
     Returns:
-        Optional[str]: The secret-key in plain text.
+        dict: The content of the secret as a dictionary.
     """
     try:
-        secret_content = model.get_secret(id=secret_id).get_content(refresh=True)
-
-        if not secret_content.get("secret-key"):
-            raise ValueError(f"The field 'secret-key' was not found in the secret '{secret_id}'.")
-        return secret_content["secret-key"]
+        return model.get_secret(id=secret_id).get_content(refresh=True)
     except ops.model.SecretNotFoundError:
         raise ops.model.SecretNotFoundError(f"The secret '{secret_id}' does not exist.")
     except ValueError as ve:


### PR DESCRIPTION
The PR adds a new credential type - `service principal`, which can be used when granular permissions are required for Azure storage access. The new type does not introduce breaking changes; the credential types can be used interchangeably.

Additionally, the PR adds two new charm config options:

- `resource-group`  - for users to be able to specify a different resource group attached to credentials
- `endpoint` - Can be used to override the default URL for Azure Storage Account, for example, a local Azure Storage deployment like [Azurite](https://github.com/Azure/Azurite).

Closes: #28 