### PR TITLE
[DPE-7940] Add resource-group, custom endpoint and support for HTTP/HTTPS

### DIFF
--- a/azure_storage/config.yaml
+++ b/azure_storage/config.yaml
@@ -18,7 +18,8 @@ options:
     type: string
     description: |
       The endpoint URL for the Azure Storage account. This is optional and can be 
-      used to override the default endpoint URL.
+      used to override the default endpoint URL, that would be generated based 
+      on the provided connection-protocol, container and storage-account.
   path:
     type: string
     description: The path inside the bucket/container to store objects.

--- a/azure_storage/config.yaml
+++ b/azure_storage/config.yaml
@@ -8,12 +8,23 @@ options:
   storage-account:
     type: string
     description: The name of the Azure storage account.
+  resource-group:
+    type: string
+    description: |
+      The name of the Azure resource group where the storage account is located. 
+      This is optional and can be used to specify a different resource group.
+    default: ''
+  endpoint:
+    type: string
+    description: |
+      The endpoint URL for the Azure Storage account. This is optional and can be 
+      used to override the default endpoint URL.
   path:
     type: string
     description: The path inside the bucket/container to store objects.
     default: ''
   connection-protocol:
-    type: string  
+    type: string
     description: |
       The storage protocol to use when connecting to Azure storage. 
       Possible values: "wasb", "wasbs" for Azure Blob Storage and 

--- a/azure_storage/config.yaml
+++ b/azure_storage/config.yaml
@@ -28,8 +28,9 @@ options:
     type: string
     description: |
       The storage protocol to use when connecting to Azure storage. 
-      Possible values: "wasb", "wasbs" for Azure Blob Storage and 
-      "abfs", "abfss" for Azure Data Lake Storage v2.
+      Possible values: "wasb", "wasbs" for Azure Blob Storage, 
+      "abfs", "abfss" for Azure Data Lake Storage Gen2 and 
+      "http", "https" for Azure Blob/Files REST API access.
     default: 'abfss'
   credentials:
     type: secret

--- a/azure_storage/src/core/context.py
+++ b/azure_storage/src/core/context.py
@@ -40,6 +40,8 @@ class Context(WithLogging):
             connection_protocol=self.charm_config.get("connection-protocol"),
             container=self.charm_config.get("container"),
             storage_account=self.charm_config.get("storage-account"),
+            endpoint=self.charm_config.get("endpoint"),
+            resource_group=self.charm_config.get("resource-group"),
             secret_key=secret_key,
             path=self.charm_config.get("path"),
         )

--- a/azure_storage/src/core/domain.py
+++ b/azure_storage/src/core/domain.py
@@ -16,11 +16,15 @@ class AzureConnectionInfo:
     container: str
     storage_account: str
     secret_key: str
+    endpoint: str = None
+    resource_group: str = None
     path: str = None
 
     @property
-    def endpoint(self):
+    def derived_endpoint(self):
         """The endpoint constructed from the other parameters."""
+        if self.endpoint:
+            return self.endpoint
         if self.connection_protocol.lower() in ("wasb", "wasbs"):
             return f"{self.connection_protocol}://{self.container}@{self.storage_account}.blob.core.windows.net/"
         elif self.connection_protocol.lower() in ("abfs", "abfss"):
@@ -34,8 +38,10 @@ class AzureConnectionInfo:
             "container": self.container,
             "storage-account": self.storage_account,
             "secret-key": self.secret_key,
-            "endpoint": self.endpoint,
+            "endpoint": self.derived_endpoint,
         }
         if self.path:
             data["path"] = self.path
+        if self.resource_group:
+            data["resource-group"] = self.resource_group
         return data

--- a/azure_storage/src/core/domain.py
+++ b/azure_storage/src/core/domain.py
@@ -29,6 +29,8 @@ class AzureConnectionInfo:
             return f"{self.connection_protocol}://{self.container}@{self.storage_account}.blob.core.windows.net/"
         elif self.connection_protocol.lower() in ("abfs", "abfss"):
             return f"{self.connection_protocol}://{self.container}@{self.storage_account}.dfs.core.windows.net/"
+        elif self.connection_protocol.lower() in ("http", "https"):
+            return f"{self.connection_protocol}://{self.storage_account}.blob.core.windows.net/{self.container}/"
         return ""
 
     def to_dict(self) -> dict:

--- a/azure_storage/src/core/domain.py
+++ b/azure_storage/src/core/domain.py
@@ -30,7 +30,7 @@ class AzureConnectionInfo:
         elif self.connection_protocol.lower() in ("abfs", "abfss"):
             return f"{self.connection_protocol}://{self.container}@{self.storage_account}.dfs.core.windows.net/"
         elif self.connection_protocol.lower() in ("http", "https"):
-            return f"{self.connection_protocol}://{self.storage_account}.blob.core.windows.net/{self.container}/"
+            return f"{self.connection_protocol}://{self.storage_account}.blob.core.windows.net/{self.container}"
         return ""
 
     def to_dict(self) -> dict:

--- a/azure_storage/tests/integration/test_azure.py
+++ b/azure_storage/tests/integration/test_azure.py
@@ -17,6 +17,7 @@ from .helpers import (
     get_relation_data,
     is_relation_broken,
     is_relation_joined,
+    run_charm_action,
     update_juju_secret,
 )
 
@@ -110,6 +111,7 @@ async def test_config_options(ops_test: OpsTest):
         "path": "/test/path_1/",
         "container": "test-container",
         "credentials": secret_uri,
+        "resource-group": "test-resource-group",
     }
     # apply new configuration options
     await ops_test.model.applications[CHARM_NAME].set_config(configuration_parameters)
@@ -117,15 +119,45 @@ async def test_config_options(ops_test: OpsTest):
     await ops_test.model.wait_for_idle(apps=[CHARM_NAME], status="active", timeout=1000)
     # test the returns
     azure_storage_integrator_unit = ops_test.model.applications[CHARM_NAME].units[0]
-    action = await azure_storage_integrator_unit.run_action(
-        action_name="get-azure-storage-connection-info"
+    configured_options = await run_charm_action(
+        azure_storage_integrator_unit, "get-azure-storage-connection-info"
     )
-    action_result = await action.wait()
-    configured_options = action_result.results
     # test the correctness of the configuration fields
     assert configured_options["storage-account"] == "stoacc"
     assert configured_options["path"] == "/test/path_1/"
     assert configured_options["secret-key"] == "**********"
+    assert configured_options["resource-group"] == "test-resource-group"
+
+
+@pytest.mark.abort_on_fail
+async def test_config_endpoint_option(ops_test: OpsTest):
+    azure_storage_integrator_unit = ops_test.model.applications[CHARM_NAME].units[0]
+
+    # abfs protocol
+    await ops_test.model.applications[CHARM_NAME].set_config({"connection-protocol": "abfss"})
+    await ops_test.model.wait_for_idle(apps=[CHARM_NAME], status="active", timeout=1000)
+    configured_options = await run_charm_action(
+        azure_storage_integrator_unit, "get-azure-storage-connection-info"
+    )
+    assert configured_options["endpoint"] == "abfss://test-container@stoacc.dfs.core.windows.net/"
+
+    # wasbs protocol
+    await ops_test.model.applications[CHARM_NAME].set_config({"connection-protocol": "wasbs"})
+    await ops_test.model.wait_for_idle(apps=[CHARM_NAME], status="active", timeout=1000)
+    configured_options = await run_charm_action(
+        azure_storage_integrator_unit, "get-azure-storage-connection-info"
+    )
+    assert configured_options["endpoint"] == "wasbs://test-container@stoacc.blob.core.windows.net/"
+
+    # custom endpoint
+    await ops_test.model.applications[CHARM_NAME].set_config(
+        {"endpoint": "https://custom.endpoint.com"}
+    )
+    await ops_test.model.wait_for_idle(apps=[CHARM_NAME], status="active", timeout=1000)
+    configured_options = await run_charm_action(
+        azure_storage_integrator_unit, "get-azure-storage-connection-info"
+    )
+    assert configured_options["endpoint"] == "https://custom.endpoint.com"
 
 
 @pytest.mark.abort_on_fail
@@ -153,6 +185,7 @@ async def test_relation_creation(ops_test: OpsTest):
     assert application_data["container"] == "test-container"
     assert application_data["storage-account"] == "stoacc"
     assert application_data["path"] == "/test/path_1/"
+    assert application_data["resource-group"] == "test-resource-group"
     secret_uri = application_data["secret-extra"]
     secret_data = await get_juju_secret(ops_test, secret_uri)
     assert secret_data["secret-key"] == "new-test-secret-key"
@@ -184,6 +217,7 @@ async def test_relation_creation(ops_test: OpsTest):
     assert application_data["container"] == new_container_name
     assert application_data["storage-account"] == "stoacc"
     assert application_data["path"] == "/test/path_1/"
+    assert application_data["resource-group"] == "test-resource-group"
 
     secret_uri = application_data["secret-extra"]
     secret_data = await get_juju_secret(ops_test, secret_uri)
@@ -203,11 +237,9 @@ async def test_secret_updated(ops_test: OpsTest):
     await ops_test.model.wait_for_idle(apps=[CHARM_NAME], status="active", timeout=1000)
     # test the returns
     azure_storage_integrator_unit = ops_test.model.applications[CHARM_NAME].units[0]
-    action = await azure_storage_integrator_unit.run_action(
-        action_name="get-azure-storage-connection-info"
+    configured_options = await run_charm_action(
+        azure_storage_integrator_unit, "get-azure-storage-connection-info"
     )
-    action_result = await action.wait()
-    configured_options = action_result.results
     # test the correctness of the configuration fields
     assert configured_options["storage-account"] == "stoacc"
     assert configured_options["path"] == "/test/path_1/"

--- a/azure_storage/tests/integration/test_azure.py
+++ b/azure_storage/tests/integration/test_azure.py
@@ -155,7 +155,7 @@ async def test_config_endpoint_option(ops_test: OpsTest):
     configured_options = await run_charm_action(
         azure_storage_integrator_unit, "get-azure-storage-connection-info"
     )
-    assert configured_options["endpoint"] == "https://stoacc.blob.core.windows.net/test-container/"
+    assert configured_options["endpoint"] == "https://stoacc.blob.core.windows.net/test-container"
 
     # custom endpoint
     await ops_test.model.applications[CHARM_NAME].set_config(

--- a/azure_storage/tests/integration/test_azure.py
+++ b/azure_storage/tests/integration/test_azure.py
@@ -149,6 +149,14 @@ async def test_config_endpoint_option(ops_test: OpsTest):
     )
     assert configured_options["endpoint"] == "wasbs://test-container@stoacc.blob.core.windows.net/"
 
+    # https protocol
+    await ops_test.model.applications[CHARM_NAME].set_config({"connection-protocol": "https"})
+    await ops_test.model.wait_for_idle(apps=[CHARM_NAME], status="active", timeout=1000)
+    configured_options = await run_charm_action(
+        azure_storage_integrator_unit, "get-azure-storage-connection-info"
+    )
+    assert configured_options["endpoint"] == "https://stoacc.blob.core.windows.net/test-container/"
+
     # custom endpoint
     await ops_test.model.applications[CHARM_NAME].set_config(
         {"endpoint": "https://custom.endpoint.com"}


### PR DESCRIPTION
The PR adds two new charm config options:

- `resource-group` - for users to be able to specify a different resource group attached to credentials
- `endpoint` - This can be used to override the default URL for an Azure Storage Account, such as a local Azure Storage deployment like [Azurite](https://github.com/Azure/Azurite).
- `https` and `http` protocol support

Reference: https://github.com/canonical/velero-operator/issues/178

Closes: #39 