### PR TITLE
[DPE-7390] Release s3-integrator charm to 2/edge

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,7 +66,7 @@ jobs:
           - s3/
           - s3/tests/integration/test-charm-s3
     name: Build charm | ${{ matrix.path }}
-    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v29.0.0
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v35.0.2
     with:
       path-to-charm-directory: ${{ matrix.path }}
       cache: false

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -76,7 +76,7 @@ jobs:
     timeout-minutes: 217 # Sum of steps `timeout-minutes` + 5
     steps:
       - name: Free up disk space
-        timeout-minutes: 1
+        timeout-minutes: 2
         run: |
           printf '\nDisk usage before cleanup\n'
           df --human-readable

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ name: Release to Charmhub
 on:
   push:
     branches:
-      - main
+      - release-s3
 
 jobs:
   lib-check:
@@ -39,14 +39,16 @@ jobs:
     strategy:
       matrix:
         charm:
-          - path: azure_storage/
-            channel: latest/edge
+          # - path: azure_storage/
+          #   track: latest
+          - path: s3/
+            track: 2
     needs:
       - lib-check
       - ci-tests
-    uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v29.0.0
+    uses: canonical/data-platform-workflows/.github/workflows/release_charm_edge.yaml@v35.0.2
     with:
-      channel: ${{ matrix.charm.channel }}
+      track: ${{ matrix.charm.track }}
       artifact-prefix: ${{ needs.ci-tests.outputs.artifact-prefix }}
       path-to-charm-directory: ${{ matrix.charm.path }}
     secrets:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ name: Release to Charmhub
 on:
   push:
     branches:
-      - release-s3
+      - main
 
 jobs:
   lib-check:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,8 +39,8 @@ jobs:
     strategy:
       matrix:
         charm:
-          # - path: azure_storage/
-          #   track: latest
+          - path: azure_storage/
+            track: latest
           - path: s3/
             track: 2
     needs:


### PR DESCRIPTION
Fixes #38 

This PR adds release workflow to release the new S3 Integrator charm to `2/edge`.