### PR TITLE
[MISC] Prevent premature writing of data in provider databag

### DIFF
--- a/s3/src/events/general.py
+++ b/s3/src/events/general.py
@@ -17,7 +17,7 @@ from pydantic import ValidationError
 
 from core.context import Context
 from core.domain import CharmConfig
-from events.base import BaseEventHandler
+from events.base import BaseEventHandler, defer_on_premature_data_access_error
 from events.statuses import CharmStatuses, ConfigStatuses
 from utils.secrets import (
     SecretDecodeError,
@@ -50,10 +50,12 @@ class GeneralEvents(BaseEventHandler, ManagerStatusProtocol):
         """Handle the charm startup event."""
         pass
 
+    @defer_on_premature_data_access_error
     def _on_update_status(self, event: ops.UpdateStatusEvent) -> None:
         """Handle the update status event."""
         self.charm.s3_provider_events.reconcile_buckets()
 
+    @defer_on_premature_data_access_error
     def _on_config_changed(self, event: ConfigChangedEvent) -> None:  # noqa: C901
         """Event handler for configuration changed events."""
         # Only execute in the unit leader
@@ -63,6 +65,7 @@ class GeneralEvents(BaseEventHandler, ManagerStatusProtocol):
         self.logger.debug(f"Config changed... Current configuration: {self.charm.config}")
         self.charm.s3_provider_events.reconcile_buckets()
 
+    @defer_on_premature_data_access_error
     def _on_secret_changed(self, event: ops.SecretChangedEvent) -> None:
         """Handle the secret changed event.
 

--- a/s3/src/events/provider.py
+++ b/s3/src/events/provider.py
@@ -16,7 +16,7 @@ from data_platform_helpers.advanced_statuses.types import Scope
 from constants import S3_RELATION_NAME
 from core.context import Context
 from core.domain import BUCKET_REGEX
-from events.base import BaseEventHandler
+from events.base import BaseEventHandler, defer_on_premature_data_access_error
 from events.statuses import BucketStatuses, CharmStatuses
 from managers.s3 import S3BucketError, S3Manager
 from s3_lib import (
@@ -49,6 +49,7 @@ class S3ProviderEvents(BaseEventHandler, ManagerStatusProtocol):
             self.charm.on[S3_RELATION_NAME].relation_broken, self._on_s3_relation_broken
         )
 
+    @defer_on_premature_data_access_error
     def _on_s3_connection_info_requested(self, event: StorageConnectionInfoRequestedEvent) -> None:
         """Handle the `storage-connection-info-requested` event."""
         self.logger.info("On storage-connection-info-requested")

--- a/s3/src/managers/s3.py
+++ b/s3/src/managers/s3.py
@@ -89,6 +89,10 @@ class S3Manager(WithLogging):
         with self.s3_resource() as resource:
             bucket: Bucket = resource.Bucket(bucket_name)
             try:
+                resource.meta.client.list_objects_v2(
+                    Bucket=bucket_name,
+                    Prefix=""
+                )
                 resource.meta.client.head_bucket(Bucket=bucket_name)
                 return bucket
             except (

--- a/s3/src/managers/s3.py
+++ b/s3/src/managers/s3.py
@@ -89,10 +89,7 @@ class S3Manager(WithLogging):
         with self.s3_resource() as resource:
             bucket: Bucket = resource.Bucket(bucket_name)
             try:
-                resource.meta.client.list_objects_v2(
-                    Bucket=bucket_name,
-                    Prefix=""
-                )
+                resource.meta.client.list_objects_v2(Bucket=bucket_name, Prefix="")
                 resource.meta.client.head_bucket(Bucket=bucket_name)
                 return bucket
             except (

--- a/s3/src/s3_lib.py
+++ b/s3/src/s3_lib.py
@@ -196,7 +196,7 @@ class S3RequirerData(RequirerData):
             model,
             relation_name,
         )
-        self._local_secret_fields = []
+        self._local_secret_fields: list[str] = []
         self.bucket = bucket
         self.path = path
 
@@ -399,8 +399,7 @@ class S3ProviderData(ProviderData):
         )
         if (
             data_from_requirer.get(relation_id, {}).get(REQ_SECRET_FIELDS) is None
-            and
-            data_from_requirer.get(relation_id, {}).get(self.RESOURCE_FIELD) is None
+            and data_from_requirer.get(relation_id, {}).get(self.RESOURCE_FIELD) is None
         ):
             raise PrematureDataAccessError(
                 "Premature access to relation data, update is forbidden before the connection is initialized."

--- a/s3/src/s3_lib.py
+++ b/s3/src/s3_lib.py
@@ -106,6 +106,7 @@ from typing import Dict, List, Optional  # using py38-style typing
 from charms.data_platform_libs.v0.data_interfaces import (
     REQ_SECRET_FIELDS,
     EventHandlers,
+    PrematureDataAccessError,
     ProviderData,
     RequirerData,
     RequirerEventHandlers,
@@ -195,6 +196,7 @@ class S3RequirerData(RequirerData):
             model,
             relation_name,
         )
+        self._local_secret_fields = []
         self.bucket = bucket
         self.path = path
 
@@ -227,7 +229,11 @@ class S3RequirerEventHandlers(RequirerEventHandlers):
     def _on_relation_joined_event(self, event: RelationJoinedEvent) -> None:
         """Event emitted when the S3 relation is joined."""
         logger.debug(f"S3 relation ({event.relation.name}) joined...")
-        event_data = {"bucket": self.relation_data.bucket, "path": self.relation_data.path}
+        event_data = {
+            "bucket": self.relation_data.bucket,
+            "path": self.relation_data.path,
+            "version": str(LIBAPI),
+        }
         self.relation_data.update_relation_data(event.relation.id, event_data)
 
     def get_s3_connection_info(self) -> Dict[str, str]:
@@ -348,6 +354,8 @@ class S3Requires(S3RequirerData, S3RequirerEventHandlers):
 class S3ProviderData(ProviderData):
     """The Data abstraction of the provider side of S3 relation."""
 
+    RESOURCE_FIELD = "bucket"
+
     def __init__(self, model: Model, relation_name: str) -> None:
         super().__init__(model, relation_name)
 
@@ -385,6 +393,18 @@ class S3ProviderData(ProviderData):
 
     def _update_relation_data(self, relation: Relation, data: Dict[str, str]) -> None:
         """Override `update_relation_data` to bypass the parent's validation that raises PrematureDataAccessError."""
+        relation_id = relation.id
+        data_from_requirer = super().fetch_relation_data(
+            [relation.id], [REQ_SECRET_FIELDS, self.RESOURCE_FIELD], relation.name
+        )
+        if (
+            data_from_requirer.get(relation_id, {}).get(REQ_SECRET_FIELDS) is None
+            and
+            data_from_requirer.get(relation_id, {}).get(self.RESOURCE_FIELD) is None
+        ):
+            raise PrematureDataAccessError(
+                "Premature access to relation data, update is forbidden before the connection is initialized."
+            )
         super(ProviderData, self)._update_relation_data(relation, data)
 
 

--- a/s3/tests/integration/test-charm-s3/src/s3_lib.py
+++ b/s3/tests/integration/test-charm-s3/src/s3_lib.py
@@ -196,7 +196,7 @@ class S3RequirerData(RequirerData):
             model,
             relation_name,
         )
-        self._local_secret_fields = []
+        self._local_secret_fields: list[str] = []
         self.bucket = bucket
         self.path = path
 
@@ -399,8 +399,7 @@ class S3ProviderData(ProviderData):
         )
         if (
             data_from_requirer.get(relation_id, {}).get(REQ_SECRET_FIELDS) is None
-            and
-            data_from_requirer.get(relation_id, {}).get(self.RESOURCE_FIELD) is None
+            and data_from_requirer.get(relation_id, {}).get(self.RESOURCE_FIELD) is None
         ):
             raise PrematureDataAccessError(
                 "Premature access to relation data, update is forbidden before the connection is initialized."

--- a/s3/tests/integration/test-charm-s3/src/s3_lib.py
+++ b/s3/tests/integration/test-charm-s3/src/s3_lib.py
@@ -106,6 +106,7 @@ from typing import Dict, List, Optional  # using py38-style typing
 from charms.data_platform_libs.v0.data_interfaces import (
     REQ_SECRET_FIELDS,
     EventHandlers,
+    PrematureDataAccessError,
     ProviderData,
     RequirerData,
     RequirerEventHandlers,
@@ -195,6 +196,7 @@ class S3RequirerData(RequirerData):
             model,
             relation_name,
         )
+        self._local_secret_fields = []
         self.bucket = bucket
         self.path = path
 
@@ -227,7 +229,11 @@ class S3RequirerEventHandlers(RequirerEventHandlers):
     def _on_relation_joined_event(self, event: RelationJoinedEvent) -> None:
         """Event emitted when the S3 relation is joined."""
         logger.debug(f"S3 relation ({event.relation.name}) joined...")
-        event_data = {"bucket": self.relation_data.bucket, "path": self.relation_data.path}
+        event_data = {
+            "bucket": self.relation_data.bucket,
+            "path": self.relation_data.path,
+            "version": str(LIBAPI),
+        }
         self.relation_data.update_relation_data(event.relation.id, event_data)
 
     def get_s3_connection_info(self) -> Dict[str, str]:
@@ -348,6 +354,8 @@ class S3Requires(S3RequirerData, S3RequirerEventHandlers):
 class S3ProviderData(ProviderData):
     """The Data abstraction of the provider side of S3 relation."""
 
+    RESOURCE_FIELD = "bucket"
+
     def __init__(self, model: Model, relation_name: str) -> None:
         super().__init__(model, relation_name)
 
@@ -385,6 +393,18 @@ class S3ProviderData(ProviderData):
 
     def _update_relation_data(self, relation: Relation, data: Dict[str, str]) -> None:
         """Override `update_relation_data` to bypass the parent's validation that raises PrematureDataAccessError."""
+        relation_id = relation.id
+        data_from_requirer = super().fetch_relation_data(
+            [relation.id], [REQ_SECRET_FIELDS, self.RESOURCE_FIELD], relation.name
+        )
+        if (
+            data_from_requirer.get(relation_id, {}).get(REQ_SECRET_FIELDS) is None
+            and
+            data_from_requirer.get(relation_id, {}).get(self.RESOURCE_FIELD) is None
+        ):
+            raise PrematureDataAccessError(
+                "Premature access to relation data, update is forbidden before the connection is initialized."
+            )
         super(ProviderData, self)._update_relation_data(relation, data)
 
 


### PR DESCRIPTION
The logic is that the provider should not write data to the databag if the requirer has not yet sent `requested-secrets` (in LIBAPI=1) or `bucket` (in LIBAPI=0). This is checked because we don't want provider share the credentials in plaintext accidentally, when the requirer is yet to establish the contract between the provider and requirer regarding which fields are to be shared as secrets and which as non secrets.

After that change in the lib, the `s3-integrator` is patched in such a way that it defers an event when it encounters premature data access error.