### PR TITLE
[MISC] Fix renovate config to include path

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,5 +12,10 @@
     "enabled": true,
     "schedule": ["* 3 * * 5"]
   },
-  "ignoreDeps": ["ubuntu"]
+  "ignoreDeps": ["ubuntu"],
+  "includePaths": [
+    "s3/**",
+    "gcs/**",
+    "azure_storage/**"
+  ]
 }


### PR DESCRIPTION
Since this is a monorepo, the renovate bot needs to scan inside the subdirectories to find the dependencies.