### PR TITLE
[PRA-269] Add support for s390x in s3-integrator in track 2

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -50,11 +50,20 @@ jobs:
               task = task.removeprefix("tests/")
               if runner.endswith("-arm"):
                   architecture = "arm64"
+              elif runner.endswith("-s390x"):
+                  architecture = "s390x"
               else:
                   architecture = "amd64"
 
               if architecture == "arm64" and "opensearch" in task:
                   # Skip arm64 for opensearch because not supported
+                  continue
+
+              if architecture == "s390x" and task not in {
+                  "s3_vm/test_config",
+                  "s3_microk8s/test_config",
+              }:
+                  # Keep s390x CI lightweight by running only packaging/deploy smoke tests
                   continue
 
               # Example: "test_charm.py:juju36 | amd64"

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -100,7 +100,7 @@ jobs:
           printf '\nDisk usage before cleanup\n'
           df --human-readable
           # Based on https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
-          rm -r /opt/hostedtoolcache/
+          rm -rf /opt/hostedtoolcache/
           printf '\nDisk usage after cleanup\n'
           df --human-readable
       - name: Checkout

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -59,10 +59,6 @@ jobs:
                   # Skip arm64 for opensearch because not supported
                   continue
 
-              if architecture != "s390x":
-                  # for test, run only s390x test
-                  continue
-
               if architecture == "s390x" and task not in {
                   "s3_vm/test_config",
                   "s3_microk8s/test_config",
@@ -132,8 +128,6 @@ jobs:
         run: |
           sudo lxc image copy ubuntu:3e7ef486d7a6 local:
           sudo lxc image alias create "juju/ubuntu@22.04/arm64" 3e7ef486d7a6
-      - name: Setup tmate session for ${{ matrix.job.spread_job }}
-        uses: canonical/action-tmate@main
       - name: Run spread job
         timeout-minutes: 180
         id: spread

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -59,12 +59,17 @@ jobs:
                   # Skip arm64 for opensearch because not supported
                   continue
 
+              if architecture != "s390x":
+                  # for test, run only s390x test
+                  continue
+
               if architecture == "s390x" and task not in {
                   "s3_vm/test_config",
                   "s3_microk8s/test_config",
               }:
                   # Keep s390x CI lightweight by running only packaging/deploy smoke tests
                   continue
+
 
               # Example: "test_charm.py:juju36 | amd64"
               name = f"{task}:{variant} | {architecture}"
@@ -127,7 +132,8 @@ jobs:
         run: |
           sudo lxc image copy ubuntu:3e7ef486d7a6 local:
           sudo lxc image alias create "juju/ubuntu@22.04/arm64" 3e7ef486d7a6
-
+      - name: Setup tmate session for ${{ matrix.job.spread_job }}
+        uses: canonical/action-tmate@main
       - name: Run spread job
         timeout-minutes: 180
         id: spread

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -48,10 +48,10 @@ jobs:
               _, runner, task, variant = job.split(":")
               # Example: "test_charm.py"
               task = task.removeprefix("tests/")
-              if runner.endswith("-arm"):
-                  architecture = "arm64"
-              elif runner.endswith("-s390x"):
+              if "s390x" in runner:
                   architecture = "s390x"
+              elif runner.endswith("-arm"):
+                  architecture = "arm64"
               else:
                   architecture = "amd64"
 

--- a/environments/concierge-microk8s.yaml
+++ b/environments/concierge-microk8s.yaml
@@ -8,5 +8,3 @@ providers:
     addons:
       - dns
       - hostpath-storage
-      - metallb:10.64.140.43-10.64.140.49
-      - minio

--- a/s3/charmcraft.yaml
+++ b/s3/charmcraft.yaml
@@ -5,6 +5,7 @@ type: charm
 platforms:
   ubuntu@24.04:amd64:
   ubuntu@24.04:arm64:
+  ubuntu@24.04:s390x:
 # Files implicitly created by charmcraft without a part:
 # - dispatch (https://github.com/canonical/charmcraft/pull/1898)
 # - manifest.yaml

--- a/s3/tests/integration/conftest.py
+++ b/s3/tests/integration/conftest.py
@@ -43,6 +43,7 @@ def platform() -> str:
     platforms = {
         "x86_64": "amd64",
         "aarch64": "arm64",
+        "s390x": "s390x",
     }
     return platforms.get(machine(), "amd64")
 

--- a/spread.yaml
+++ b/spread.yaml
@@ -91,7 +91,9 @@ backends:
           username: ubuntu
           environment:
             # Microk8s is only available in edge channel in s390x arch
-            CONCIERGE_MICROK8S_CHANNEL: 1.32-strict/edge
+            # IS-hosted GitHub runners do not work with the strictly confined microk8s snap
+            CONCIERGE_MICROK8S_CHANNEL: latest/edge
+            CONCIERGE_EXTRA_DEBS: pipx,pkg-config,rustup
 
 suites:
   tests/azure_storage_microk8s/:
@@ -137,8 +139,38 @@ prepare: |
   cd "$SPREAD_PATH"
   snap install --classic concierge
 
+  if [[ -n "$DOCKERHUB_MIRROR" ]]
+  then
+    # Running on IS-hosted runner; configure microk8s to use Docker Hub mirror
+    # Run before concierge prepare because of https://github.com/canonical/concierge/issues/75
+
+    snap install microk8s --channel "$CONCIERGE_MICROK8S_CHANNEL" --classic
+  
+    # Wait for microk8s to populate iptables
+    # https://chat.canonical.com/canonical/pl/jo5cg6wqjjrudqd5ybj6hhttee
+    microk8s status --wait-ready
+
+    tee /var/snap/microk8s/current/args/certs.d/docker.io/hosts.toml << EOF
+    server = "$DOCKERHUB_MIRROR"
+    [host."${DOCKERHUB_MIRROR#'https://'}"]
+    capabilities = ["pull", "resolve"]
+  EOF
+    microk8s stop
+    microk8s start
+  fi
+
   # Install charmcraft & pipx (on lxd-vm backend)
   concierge prepare --trace
+
+  microk8s config | juju add-k8s my-k8s --client
+  juju bootstrap my-k8s concierge-microk8s
+  juju add-model testing
+
+  if [[ $SPREAD_SYSTEM == *"s390x"* ]]
+  then
+    rustup set profile minimal
+    rustup default 1.88.0
+  fi
 
   pipx install tox
   pipx install poetry

--- a/spread.yaml
+++ b/spread.yaml
@@ -167,12 +167,13 @@ prepare: |
   # Install charmcraft & pipx (on lxd-vm backend)
   concierge prepare --trace
 
-  microk8s config | juju add-k8s my-k8s --client
-  juju bootstrap my-k8s concierge-microk8s
-  juju add-model testing
-
   if [[ $SPREAD_SYSTEM == *"s390x"* ]]
   then
+    # On s390x self-hosted runners, ensure a microk8s cloud/controller exists.
+    microk8s config | juju add-k8s my-k8s --client || true
+    juju bootstrap my-k8s concierge-microk8s || true
+    juju add-model testing || true
+
     rustup set profile minimal
     rustup default 1.88.0
   fi

--- a/spread.yaml
+++ b/spread.yaml
@@ -88,7 +88,7 @@ backends:
       - ubuntu-22.04-arm: # TODO: Revert back to noble when LXD flakiness is fixed
           username: runner
       - self-hosted-linux-s390x-noble-medium:
-          username: runner
+          username: ubuntu
 
 suites:
   tests/azure_storage_microk8s/:

--- a/spread.yaml
+++ b/spread.yaml
@@ -82,6 +82,7 @@ backends:
     environment:
       CI: '$(HOST: echo $CI)'
       CHARM_UBUNTU_BASE: '$(HOST: echo $CHARM_UBUNTU_BASE)'
+      DOCKERHUB_MIRROR: '$(HOST: echo $DOCKERHUB_MIRROR)'
     systems:
       - ubuntu-22.04: # TODO: Revert back to noble when LXD flakiness is fixed
           username: runner

--- a/spread.yaml
+++ b/spread.yaml
@@ -87,7 +87,7 @@ backends:
           username: runner
       - ubuntu-24.04-arm:
           username: runner
-      - ubuntu-24.04-s390x:
+      - self-hosted-linux-s390x-noble-medium:
           username: runner
 
 suites:

--- a/spread.yaml
+++ b/spread.yaml
@@ -89,6 +89,9 @@ backends:
           username: runner
       - self-hosted-linux-s390x-noble-medium:
           username: ubuntu
+          environment:
+            # Microk8s is only available in edge channel in s390x arch
+            CONCIERGE_MICROK8S_CHANNEL: 1.32-strict/edge
 
 suites:
   tests/azure_storage_microk8s/:

--- a/spread.yaml
+++ b/spread.yaml
@@ -87,6 +87,8 @@ backends:
           username: runner
       - ubuntu-24.04-arm:
           username: runner
+      - ubuntu-24.04-s390x:
+          username: runner
 
 suites:
   tests/azure_storage_microk8s/:

--- a/spread.yaml
+++ b/spread.yaml
@@ -151,6 +151,10 @@ prepare: |
     # https://chat.canonical.com/canonical/pl/jo5cg6wqjjrudqd5ybj6hhttee
     microk8s status --wait-ready
 
+    # Enable storage and rbac addons
+    microk8s enable hostpath-storage rbac
+    microk8s status --wait-ready
+
     tee /var/snap/microk8s/current/args/certs.d/docker.io/hosts.toml << EOF
     server = "$DOCKERHUB_MIRROR"
     [host."${DOCKERHUB_MIRROR#'https://'}"]

--- a/tests/s3_microk8s/test_compat_mysql_8_edge/task.yaml
+++ b/tests/s3_microk8s/test_compat_mysql_8_edge/task.yaml
@@ -10,6 +10,4 @@ execute: |
   tox run -e integration -- -x "tests/integration/$TEST_MODULE" --trust \
                             --charm mysql-k8s \
                             --base ubuntu@24.04 \
-                            --channel-v1 8.4/edge/pr-88 \
-                            --channel-v0 8.4/edge \
-                            --upgrade
+                            --channel-v1 8.4/edge


### PR DESCRIPTION
Fixes #146 

This PR adds support for s390x in s3-integrator. This was added recently in `s3-integrator` from `1/stable` via https://github.com/canonical/s3-integrator/pull/173, but was missing in `2/edge`.