### PR TITLE
[MISC] Revert pinning jammy runner in CI

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -83,9 +83,9 @@ backends:
       CI: '$(HOST: echo $CI)'
       CHARM_UBUNTU_BASE: '$(HOST: echo $CHARM_UBUNTU_BASE)'
     systems:
-      - ubuntu-22.04: # TODO: Revert back to noble when LXD flakiness is fixed
+      - ubuntu-24.04:
           username: runner
-      - ubuntu-22.04-arm: # TODO: Revert back to noble when LXD flakiness is fixed
+      - ubuntu-24.04-arm:
           username: runner
 
 suites:


### PR DESCRIPTION
This PR aims to revert the pinning of `jammy` runner in CI. We pinned `jammy` because the CI was failing in `noble` due to issues in LXD. The aim of this PR is that we want to be ready to revert back the pinning quite soon after the LXD issue gets resolved.