### PR TITLE
[MISC] Fix s3-integrator to not crash on empty endpoint

### DIFF
--- a/s3/src/managers/s3.py
+++ b/s3/src/managers/s3.py
@@ -89,6 +89,7 @@ class S3Manager(WithLogging):
         """Yield a boto3 S3 resource, handling TLS CA chain cleanup safely."""
         ca_file: str | None = None
         extra_args: dict[str, object] = {}
+        endpoint = self.conn_info.get("endpoint") or None
 
         if self.conn_info.get("tls-ca-chain"):
             ca_chain_pem: str = "\n".join(self.conn_info["tls-ca-chain"])
@@ -110,7 +111,7 @@ class S3Manager(WithLogging):
         )
 
         # Set up proxy configuration only if the endpoint is not in no_proxy list
-        if not self.skip_proxy(self.conn_info.get("endpoint", "")):
+        if not self.skip_proxy(endpoint or ""):
             proxy_config: dict[str, str] = {}
             if os.environ.get("JUJU_CHARM_HTTPS_PROXY"):
                 proxy_config["https"] = os.environ["JUJU_CHARM_HTTPS_PROXY"]
@@ -131,7 +132,7 @@ class S3Manager(WithLogging):
             S3ServiceResource,
             session.resource(
                 service_name="s3",
-                endpoint_url=self.conn_info.get("endpoint"),
+                endpoint_url=endpoint,
                 config=config,
                 **extra_args,
             ),  # type: ignore
@@ -145,47 +146,51 @@ class S3Manager(WithLogging):
 
     def get_bucket(self, bucket_name: str, path: str = "") -> Bucket | None:
         """Fetch the bucket with given name from S3 cloud."""
-        with self.s3_resource() as resource:
-            bucket: Bucket = resource.Bucket(bucket_name)
-            prefix = path[1:] if path.startswith("/") else path
-            try:
+        try:
+            with self.s3_resource() as resource:
+                bucket: Bucket = resource.Bucket(bucket_name)
+                prefix = path[1:] if path.startswith("/") else path
                 resource.meta.client.list_objects_v2(Bucket=bucket_name, Prefix=prefix)
                 return bucket
-            except (
-                ClientError,
-                SSLError,
-                ConnectTimeoutError,
-                ParamValidationError,
-                EndpointConnectionError,
-                ProxyConnectionError,
-            ) as e:
-                self.logger.error(f"The bucket '{bucket_name}' can't be fetched; Response: {e}")
-                return None
+        except (
+            ClientError,
+            SSLError,
+            ConnectTimeoutError,
+            ParamValidationError,
+            EndpointConnectionError,
+            ProxyConnectionError,
+            ValueError,
+        ) as e:
+            self.logger.error(f"The bucket '{bucket_name}' can't be fetched; Response: {e}")
+            return None
 
     def create_bucket(self, bucket_name: str, wait_until_exists: bool = True) -> Bucket:
         """Create a bucket with given name in the S3 cloud."""
-        with self.s3_resource() as resource:
-            bucket: Bucket = resource.Bucket(bucket_name)
-            create_args = {}
-            region = self.conn_info.get("region")
-            if region and region != "us-east-1":
-                create_args = {
-                    "CreateBucketConfiguration": {"LocationConstraint": self.conn_info["region"]}
-                }
-            try:
+        try:
+            with self.s3_resource() as resource:
+                bucket: Bucket = resource.Bucket(bucket_name)
+                create_args = {}
+                region = self.conn_info.get("region")
+                if region and region != "us-east-1":
+                    create_args = {
+                        "CreateBucketConfiguration": {
+                            "LocationConstraint": self.conn_info["region"]
+                        }
+                    }
                 bucket.create(**create_args)  # type: ignore
                 if wait_until_exists:
                     bucket.wait_until_exists()
                 return bucket
-            except (
-                SSLError,
-                ConnectTimeoutError,
-                ClientError,
-                ParamValidationError,
-                EndpointConnectionError,
-                ProxyConnectionError,
-            ) as e:
-                self.logger.error(f"Could not create the bucket '{bucket_name}'; Response: {e}")
-                raise S3BucketError(
-                    f"Could not create bucket '{bucket_name}' using provided configuration"
-                )
+        except (
+            SSLError,
+            ConnectTimeoutError,
+            ClientError,
+            ParamValidationError,
+            EndpointConnectionError,
+            ProxyConnectionError,
+            ValueError,
+        ) as e:
+            self.logger.error(f"Could not create the bucket '{bucket_name}'; Response: {e}")
+            raise S3BucketError(
+                f"Could not create bucket '{bucket_name}' using provided configuration"
+            )

--- a/s3/tests/integration/test_config.py
+++ b/s3/tests/integration/test_config.py
@@ -147,3 +147,15 @@ def test_config_existing_bucket_name_valid_keys(juju: jubilant.Juju, pre_created
     juju.wait(
         lambda status: jubilant.all_active(status) and jubilant.all_agents_idle(status), delay=5
     )
+
+
+def test_config_empty_endpoint_does_not_crash(juju: jubilant.Juju) -> None:
+    """Test that the charm gracefully handles empty endpoint config with valid bucket and credentials."""
+    # Ensure endpoint is explicitly empty
+    juju.config(S3, reset="endpoint")
+    # Charm should degrade to blocked status instead of crashing
+    status = juju.wait(
+        lambda status: jubilant.all_blocked(status) and jubilant.all_agents_idle(status), delay=5
+    )
+    assert "Could not ensure bucket" in status.apps[S3].app_status.message
+    assert "Could not ensure bucket" in status.apps[S3].units[f"{S3}/0"].workload_status.message

--- a/s3/tests/unit/test_provider.py
+++ b/s3/tests/unit/test_provider.py
@@ -137,6 +137,42 @@ def test_provider_when_ensure_bucket_unsuccessful(
 
 
 @patch("utils.secrets.decode_secret_key_with_retry", decode_secret_key)
+@patch("managers.s3.S3Manager.s3_resource", side_effect=ValueError("Invalid endpoint"))
+def test_provider_empty_endpoint_manager_init_failure_does_not_crash(
+    mock_s3_resource,
+    charm_configuration: dict,
+    base_state: State,
+    valid_ca_chain: bytes,
+) -> None:
+    """Check provider gracefully degrades when S3 manager initialization fails with empty endpoint."""
+    # Given
+    credentials_secret = Secret(
+        tracked_content={"access-key": "my-access-key", "secret-key": "my-secret-key"}
+    )
+    charm_configuration["options"]["bucket"]["default"] = "config-bucket"
+    charm_configuration["options"]["endpoint"]["default"] = ""
+    charm_configuration["options"]["credentials"]["default"] = credentials_secret.id
+
+    ca_chain_encoded = base64.b64encode(valid_ca_chain).decode()
+    charm_configuration["options"]["tls-ca-chain"]["default"] = ca_chain_encoded
+    ctx = Context(
+        S3IntegratorCharm,
+        meta=METADATA,
+        config=charm_configuration,
+        actions=ACTIONS,
+        unit_id=0,
+    )
+    state_in = dataclasses.replace(base_state, secrets=[credentials_secret])
+
+    # When
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    # Then: no exception from reconcile path and blocked status instead of crash
+    assert isinstance(state_out.unit_status, BlockedStatus)
+    assert "Could not ensure bucket(s): 'config-bucket'" in state_out.unit_status.message
+
+
+@patch("utils.secrets.decode_secret_key_with_retry", decode_secret_key)
 @patch("managers.s3.S3Manager.get_bucket", return_value=True)
 def test_provider_config_bucket_takes_priority_over_relation_bucket(
     mock_get_bucket,


### PR DESCRIPTION
The S3 endpoint crashed when the `bucket` param was provided but not the `endpoint` parameter. To prevent this, this PR makes sure to pass `None` into boto3 call when the endpoint is not specified.